### PR TITLE
[AT][Home][Topmenu][Login or register] testLoginMenuCustomerText_changesAfterLogin() <verafes>

### DIFF
--- a/src/test/java/pages/home/HomePage.java
+++ b/src/test/java/pages/home/HomePage.java
@@ -8,6 +8,9 @@ import pages.home.account.AccountLoginPage;
 
 public class HomePage extends MainPage {
 
+    @FindBy(xpath = "//ul[@id='customer_menu_top']")
+    private WebElement loginCustomerTopMenu;
+
     @FindBy(xpath = "//ul[@id='main_menu_top']//a[@class='top menu_account']")
     private WebElement accountTopMenu;
 
@@ -19,5 +22,16 @@ public class HomePage extends MainPage {
         click(accountTopMenu);
 
         return new AccountLoginPage(getDriver());
+    }
+
+    public AccountLoginPage clickLoginCustomerMenu() {
+        click(loginCustomerTopMenu);
+
+        return new AccountLoginPage(getDriver());
+    }
+
+    public String getLoginCustomerText() {
+
+        return getText(loginCustomerTopMenu);
     }
 }

--- a/src/test/java/tests/home/account/AccountLoginTest.java
+++ b/src/test/java/tests/home/account/AccountLoginTest.java
@@ -1,7 +1,28 @@
 package tests.home.account;
 
 import base.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import pages.home.HomePage;
 
 public class AccountLoginTest extends BaseTest {
 
+    @Test
+    public void testLoginMenuCustomerText_changesAfterLogin() {
+        final String expectedLoginMenuText = "Welcome back Test";
+
+        HomePage homePage = new HomePage(getDriver());
+
+        String oldLoginMenuText = openBaseURL().getLoginCustomerText();
+
+        homePage.clickLoginCustomerMenu()
+                .clickClearInputRegularUserLogin("testtestoff940")
+                .clickClearInputRegularUserPassword("Testoff29012003")
+                .clickLoginButton();
+
+        String actualLoginMenuText = homePage.getLoginCustomerText();
+
+        Assert.assertNotEquals(oldLoginMenuText, actualLoginMenuText);
+        Assert.assertEquals(actualLoginMenuText, expectedLoginMenuText);
+    }
 }


### PR DESCRIPTION
testLoginMenuCustomerText_changesAfterLogin() added

[TC] https://trello.com/c/H3EI6CIw/2-tchometopmenulogin-or-register-login-or-register-menu-text-changes-to-welcome-back-test-after-sucsessful-login-verafes
[AT] https://trello.com/c/sVcdTYkM/3-athometopmenulogin-or-register-testloginmenucustomertextchangesafterlogin-verafes